### PR TITLE
Fixed when-visible check.

### DIFF
--- a/src/angular-scroll-animate.js
+++ b/src/angular-scroll-animate.js
@@ -57,7 +57,7 @@ angular.module('angular-scroll-animate', []).directive('whenVisible', ['$documen
         var bottomVisible = (panelBottom - delayPx > 0) && (panelBottom < viewportHeight);
         var topVisible = (panelTop + delayPx <= viewportHeight) && (panelTop > 0);
 
-        if ($el.data('hidden') && bottomVisible || topVisible) {
+        if ($el.data('hidden') && (bottomVisible || topVisible)) {
           whenVisibleFn($el, scope);
           $el.data('hidden', false);
         }


### PR DESCRIPTION
With this small change in IF condition, whenVisibleFn is executed exactly one time when the element gets visible. Previous implementation made the condition if ($el.data('hidden') && bottomVisible || topVisible) pass every time a topVisible was true. Therefore, it would execute a whenVisibleFn too often.
