### PR TITLE
Remove version from bower.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
 
     watch: {
            scripts: {
-                    files: ['src/**/*'],
+                    files: ['src/**/*', 'example/**/*'],
                     tasks: ['beautify', 'build'],
                     options: {
                              spawn: false

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "angular-scroll-animate",
-  "version": "0.8.0",
   "license": "MIT",
   "main": [
     "dist/angular-scroll-animate.js"

--- a/dist/angular-scroll-animate.js
+++ b/dist/angular-scroll-animate.js
@@ -6,8 +6,10 @@ angular.module('angular-scroll-animate', []);// Source: src/angular-scroll-anima
  * @restrict A
  * @param {string} when-not-visible function to execute when element is scrolled into viewport
  * @param {string=} when-not-visible function to execute when element is scrolled out of viewport
- * @param {delayPercent=} percentage (of px) to delay animate when visible transition.
- * @param {bindScrollTo=} override default scroll event binding to another parent container.
+ * @param {number=} delayPercent percentage (of px) to delay animate when visible transition.
+ * @param {number=} delayPercentViewport percentage (of viewport height) to delay animate when visible transition.
+ * @param {number=} delayPixels to delay animate when visible transition.
+ * @param {string=} bindScrollTo override default scroll event binding to another parent container.
  *
  * @description
  * Allows method hooks into the detection of when an element is scrolled into or out of view.
@@ -16,7 +18,8 @@ angular.module('angular-scroll-animate', []);// Source: src/angular-scroll-anima
  * <example module="angular-scroll-animate">
  *   <file name="index.html">
  *     <div ng-controller="ExampleCtrl">
- *       <div class="car" when-visible="animateIn" when-not-visible="animateOut">Broom</div>
+ *       <div class="car" when-visible="animateIn">Broom with simplest config</div>
+ *       <div class="car" when-visible="animateIn" when-not-visible="animateOut" delay-pixels="50" delay-percent="0.25" delay-percent-viewport="0.1">Broom with all options</div>
  *     </div>
  *   </file>
  *   <file name="controller.js">
@@ -44,20 +47,37 @@ angular.module('angular-scroll-animate', []).directive('whenVisible', ['$documen
  function($document, $window) {
 
     var determineWhereElementIsInViewport =
-      function($el, viewportHeight, whenVisibleFn, whenNotVisibleFn, delayPercent, scope) {
+      function($el, document, whenVisibleFn, whenNotVisibleFn, delayPercent, delayPercentViewport, delayPixels, scope) {
 
         var elementBounds = $el[0].getBoundingClientRect();
+        var viewportHeight = document.clientHeight;
 
         var panelTop = elementBounds.top;
         var panelBottom = elementBounds.bottom;
 
-        // pixel buffer until deciding to show the element
-        var delayPx = delayPercent * elementBounds.height;
+        var delayPx; // pixel buffer until deciding to show the element
+        var delayPxValues = [];
+        if (delayPixels) {
+          delayPxValues.push(delayPixels);
+        }
+        if (delayPercentViewport) {
+          delayPxValues.push(delayPercentViewport * $window.innerHeight);
+        }
+        if (delayPercent) {
+          delayPxValues.push(delayPercent * elementBounds.height);
+        }
+
+        if (delayPxValues.length === 0) {
+          delayPx = 0.25 * elementBounds.height;
+        }
+        else {
+          delayPx = Math.min.apply(Math, delayPxValues); //Show element as soon as any delay has been fulfilled
+        }
 
         var bottomVisible = (panelBottom - delayPx > 0) && (panelBottom < viewportHeight);
         var topVisible = (panelTop + delayPx <= viewportHeight) && (panelTop > 0);
 
-        if ($el.data('hidden') && bottomVisible || topVisible) {
+        if ($el.data('hidden') && (bottomVisible || topVisible)) {
           whenVisibleFn($el, scope);
           $el.data('hidden', false);
         }
@@ -75,6 +95,8 @@ angular.module('angular-scroll-animate', []).directive('whenVisible', ['$documen
         whenVisible: '&',
         whenNotVisible: '&?',
         delayPercent: '=?',
+        delayPercentViewport: '=?',
+        delayPixels: '=?',
         bindScrollTo: '@?'
       },
 
@@ -104,13 +126,14 @@ angular.module('angular-scroll-animate', []).directive('whenVisible', ['$documen
 
       link: function(scope, el, attributes) {
 
-        var delayPercent = attributes.delayPercent || 0.25; // lower = more eager to hide / show, higher = less eager
+        var delayPercent = attributes.delayPercent; //Fallback is be 0.25% delayPercent if no delay is specified, set in determineWhereElementIsInViewport function
+        var delayPercentViewport = attributes.delayPercentViewport;
+        var delayPixels = attributes.delayPixels;
         var document = $document[0].documentElement;
         var checkPending = false;
 
         var updateVisibility = function() {
-          determineWhereElementIsInViewport(el, document.clientHeight /* viewportHeight */ ,
-            scope.whenVisible(), scope.whenNotVisible(), delayPercent, scope);
+          determineWhereElementIsInViewport(el, document, scope.whenVisible(), scope.whenNotVisible(), delayPercent, delayPercentViewport, delayPixels, scope);
 
           checkPending = false;
         };

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,16 +18,16 @@
     // before the base attribute is added, causing 404 and terribly slow loading of the docs app.
     (function() {
       var indexFile = (location.pathname.match(/\/(index[^\.]*\.html)/) || ['', ''])[1],
-          origin, baseUrl, rUrl = /(#!\/|api|index[^\.]*\.html).*$/,
+          origin, baseUrl, rUrl = /(\/?#!\/.*|\/(api)\/?(\?.*)*|\/index[^\.]*\.html.*)$/,
           headEl = document.getElementsByTagName('head')[0],
           sync = true;
 
       if (location.href.slice(0, 7) == 'file://') {
-        baseUrl = location.href.replace(rUrl, indexFile);
+        baseUrl = location.href.replace(rUrl, '/' + indexFile);
       } else {
         origin = location.origin || (window.location.protocol + "//" + window.location.hostname +
                                     (window.location.port ? ':' + window.location.port: ''));
-        baseUrl = origin + location.href.substr(origin.length).replace(rUrl, indexFile);
+        baseUrl = origin + location.href.substr(origin.length).replace(rUrl, '/' + indexFile);
       }
 
       addTag('base', {href: baseUrl});

--- a/docs/js/docs-setup.js
+++ b/docs/js/docs-setup.js
@@ -10,7 +10,7 @@ NG_DOCS={
       "type": "directive",
       "moduleName": "angular-scroll-animate",
       "shortDescription": "Allows method hooks into the detection of when an element is scrolled into or out of view.",
-      "keywords": "$el $scope addclass allows angular angular-scroll-animate animate animatein animateout animations api binding car class container controller css default delay detection directive ease-in element event example examplectrl execute fadein function hidden hooks html js method module ng-controller override parent percentage px removeclass removeclassclass scroll scrolled transition view viewport visibility visible when-not-visible when-visible"
+      "keywords": "$el $scope addclass allows angular angular-scroll-animate animate animatein animateout animations api binding bindscrollto car class config container controller css default delay delay-percent delay-percent-viewport delay-pixels delaypercent delaypercentviewport delaypixels detection directive ease-in element event example examplectrl execute fadein function height hidden hooks html js method module ng-controller options override parent percentage px removeclass removeclassclass scroll scrolled simplest transition view viewport visibility visible when-not-visible when-visible"
     }
   ],
   "apis": {

--- a/docs/partials/api/angular-scroll-animate.directive.when-visible.html
+++ b/docs/partials/api/angular-scroll-animate.directive.when-visible.html
@@ -1,4 +1,4 @@
-<a href="https://github.com/rpocklin/angular-scroll-animate.git/edit/master/dist/angular-scroll-animate.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/rpocklin/angular-scroll-animate.git/blob/fb82569/dist/angular-scroll-animate.js#L43" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">when-visible</code>
+<a href="https://github.com/rpocklin/angular-scroll-animate/edit/master/dist/angular-scroll-animate.js" class="improve-docs"><i class="icon-edit"> </i>Improve this doc</a><a href="https://github.com/rpocklin/angular-scroll-animate/blob/c8e1d3c/dist/angular-scroll-animate.js#L46" class="view-source"><i class="icon-eye-open"> </i>View source</a><h1><code ng:non-bindable="">when-visible</code>
 <div><span class="hint">directive in module <code ng:non-bindable="">angular-scroll-animate</code>
 </span>
 </div>
@@ -10,14 +10,18 @@
 <div class="usage">as attribute<pre class="prettyprint linenums">&lt;ANY when-visible
      when-not-visible="{string}"
      [when-not-visible="{string}"]
-     [percentage="{delayPercent}"]
-     [override="{bindScrollTo}"]&gt;
+     [delay-percent="{number}"]
+     [delay-percent-viewport="{number}"]
+     [delay-pixels="{number}"]
+     [bind-scroll-to="{string}"]&gt;
    ...
 &lt;/ANY&gt;</pre>
 <h4 id="usage_parameters">Parameters</h4><table class="variables-matrix table table-bordered table-striped"><thead><tr><th>Param</th><th>Type</th><th>Details</th></tr></thead><tbody><tr><td>when-not-visible</td><td><a href="" class="label type-hint type-hint-string">string</a></td><td><div class="angular-scroll-animate-directive-page angular-scroll-animate-directive-when-visible-page"><p>function to execute when element is scrolled into viewport</p>
 </div></td></tr><tr><td>when-not-visible <div><em>(optional)</em></div></td><td><a href="" class="label type-hint type-hint-string">string</a></td><td><div class="angular-scroll-animate-directive-page angular-scroll-animate-directive-when-visible-page"><p>function to execute when element is scrolled out of viewport</p>
-</div></td></tr><tr><td>percentage <div><em>(optional)</em></div></td><td><a href="" class="label type-hint type-hint-delaypercent">delayPercent</a></td><td><div class="angular-scroll-animate-directive-page angular-scroll-animate-directive-when-visible-page"><p>(of px) to delay animate when visible transition.</p>
-</div></td></tr><tr><td>override <div><em>(optional)</em></div></td><td><a href="" class="label type-hint type-hint-bindscrollto">bindScrollTo</a></td><td><div class="angular-scroll-animate-directive-page angular-scroll-animate-directive-when-visible-page"><p>default scroll event binding to another parent container.</p>
+</div></td></tr><tr><td>delayPercent <div><em>(optional)</em></div></td><td><a href="" class="label type-hint type-hint-number">number</a></td><td><div class="angular-scroll-animate-directive-page angular-scroll-animate-directive-when-visible-page"><p>percentage (of px) to delay animate when visible transition.</p>
+</div></td></tr><tr><td>delayPercentViewport <div><em>(optional)</em></div></td><td><a href="" class="label type-hint type-hint-number">number</a></td><td><div class="angular-scroll-animate-directive-page angular-scroll-animate-directive-when-visible-page"><p>percentage (of viewport height) to delay animate when visible transition.</p>
+</div></td></tr><tr><td>delayPixels <div><em>(optional)</em></div></td><td><a href="" class="label type-hint type-hint-number">number</a></td><td><div class="angular-scroll-animate-directive-page angular-scroll-animate-directive-when-visible-page"><p>to delay animate when visible transition.</p>
+</div></td></tr><tr><td>bindScrollTo <div><em>(optional)</em></div></td><td><a href="" class="label type-hint type-hint-string">string</a></td><td><div class="angular-scroll-animate-directive-page angular-scroll-animate-directive-when-visible-page"><p>override default scroll event binding to another parent container.</p>
 </div></td></tr></tbody></table></div>
 <h2 id="example">Example</h2>
 <div class="example"><div class="angular-scroll-animate-directive-page angular-scroll-animate-directive-when-visible-page"><h4 id="example_source">Source</h4>
@@ -26,7 +30,8 @@
 <pre class="prettyprint linenums" ng-set-text="index.html" ng-html-wrap-loaded="angular-scroll-animate angular.js controller.js"></pre>
 <script type="text/ng-template" id="index.html">
   <div ng-controller="ExampleCtrl">
-    <div class="car" when-visible="animateIn" when-not-visible="animateOut">Broom</div>
+    <div class="car" when-visible="animateIn">Broom with simplest config</div>
+    <div class="car" when-visible="animateIn" when-not-visible="animateOut" delay-pixels="50" delay-percent="0.25" delay-percent-viewport="0.1">Broom with all options</div>
   </div>
 </script>
 </div>

--- a/example/example.html
+++ b/example/example.html
@@ -115,6 +115,7 @@
 
 	<div class="spacer"></div>
 
+<h2>Default delay</h2>
 	<div ng-repeat="car in cars" when-visible="animateElementIn" when-not-visible="animateElementOut" class="hidden car-container">
 		<div class="car">
 			<h3>{{car.name}}</h3>
@@ -123,4 +124,50 @@
 	</div>
 
 	<div class="spacer"></div>
+
+	<h2>100% (of element) delay</h2>
+	<div ng-repeat="car in cars" when-visible="animateElementIn" when-not-visible="animateElementOut" delay-percent="1.0" class="hidden car-container">
+		<div class="car">
+			<h3>{{car.name}}</h3>
+			<div>{{car.description}}</div>
+		</div>
+	</div>
+
+	<div class="spacer"></div>
+
+
+	<h2>20px delay</h2>
+	<div ng-repeat="car in cars" when-visible="animateElementIn" when-not-visible="animateElementOut" delay-pixels="20" class="hidden car-container">
+		<div class="car">
+			<h3>{{car.name}}</h3>
+			<div>{{car.description}}</div>
+		</div>
+	</div>
+
+	<div class="spacer"></div>
+
+
+	<h2>50% of viewport delay</h2>
+	<p>If full element is visible it will always animate in - try a small browser window!</p>
+	<div ng-repeat="car in cars" when-visible="animateElementIn" when-not-visible="animateElementOut" delay-percent-viewport="0.5" class="hidden car-container">
+		<div class="car">
+			<h3>{{car.name}}</h3>
+			<div>{{car.description}}</div>
+		</div>
+	</div>
+
+	<div class="spacer"></div>
+
+
+	<h2>Combination delay (50px, 25% of element and 10% of viewport)</h2>
+	<div ng-repeat="car in cars" when-visible="animateElementIn" when-not-visible="animateElementOut" delay-pixels="50" delay-percent="0.25" delay-percent-viewport="0.1" class="hidden car-container">
+		<div class="car">
+			<h3>{{car.name}}</h3>
+			<div>{{car.description}}</div>
+		</div>
+	</div>
+
+	<div class="spacer"></div>
+
+
 </div>

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "type": "git",
     "url": "http://github.com/rpocklin/angular-scroll-animate.git"
   },
-  "main": [
-    "src/angular-scroll-animate.js"
-  ],
+  "main": ["src/angular-scroll-animate.js"],
   "keywords": [
     "angular",
     "directive",

--- a/src/angular-scroll-animate.js
+++ b/src/angular-scroll-animate.js
@@ -57,7 +57,7 @@ angular.module('angular-scroll-animate', []).directive('whenVisible', ['$documen
         var bottomVisible = (panelBottom - delayPx > 0) && (panelBottom < viewportHeight);
         var topVisible = (panelTop + delayPx <= viewportHeight) && (panelTop > 0);
 
-        if ($el.data('hidden') && bottomVisible || topVisible) {
+        if ($el.data('hidden') && (bottomVisible || topVisible)) {
           whenVisibleFn($el, scope);
           $el.data('hidden', false);
         }


### PR DESCRIPTION
Despite the version in bower.json not being the most recent one, according to [bower spec](https://github.com/bower/spec/blob/master/json.md#version) `version` is deprecated.

The annoying warning `bower mismatch Version declared in the json (0.8.0) is different than the resolved one (0.9.8)` should go away.
